### PR TITLE
Correcoes e melhorias - Bradesco/Pagina de sucesso/getOrder do bloco

### DIFF
--- a/app/code/community/MageBR/BoletoBancario/Block/Standard/Info.php
+++ b/app/code/community/MageBR/BoletoBancario/Block/Standard/Info.php
@@ -40,7 +40,14 @@ class MageBR_BoletoBancario_Block_Standard_Info extends Mage_Payment_Block_Info
      */
     public function getOrder()
     {
-        return Mage::registry('current_order');
+        if(Mage::registry('current_order')){
+            return Mage::registry('current_order');
+        }else if($lastOrderId = Mage::getSingleton('checkout/session')->getLastRealOrderId())
+        {
+            return Mage::getModel('sales/order')->loadByIncrementId($lastOrderId);
+        }
+
+        return parent::getOrder();
     }
 
 	public function getStandard()

--- a/app/design/frontend/base/default/template/BoletoBancario/standard/info.phtml
+++ b/app/design/frontend/base/default/template/BoletoBancario/standard/info.phtml
@@ -43,11 +43,11 @@
 	<?php } ?>
 			
 			<?php if (strpos($_SERVER['REQUEST_URI'], 'success') !== false) { ?>
-				<p>VocÃª serÃ¡ redirecionado para a pÃ¡gina de impressÃ£o do boleto em 5 segundos. <br />
-					Se isso nÃ£o ocorrer, clique no botÃ£o "Exibir Boleto".
+				<p>Voc&ecirc; ser&aacute; redirecionado para a p&aacute;gina de impress&atilde;o do boleto em 5 segundos. <br />
+					Se isso n&atilde;o ocorrer, clique no bot&atilde;o "Exibir Boleto".
 				</p>
 				<script type="text/javascript"> 
-					window.setTimeout('abreJanelaBoleto(false)', 5000);
+					window.setTimeout('abreJanelaBoleto(true)', 5000);
 				</script>
 			<?php } ?>
 
@@ -102,17 +102,17 @@ else : { ?>
 					}
 				}
 			</script>
-			
+			<?php /*
 			<?php if (strpos($_SERVER['REQUEST_URI'], 'success') !== false) { ?>
-				<p>VocÃª serÃ¡ redirecionado para a pÃ¡gina de impressÃ£o do boleto em 5 segundos. <br />
-					Se isso nÃ£o ocorrer, clique no botÃ£o "Exibir Boleto".
+				<p>Voc&ecirc; ser&aacute; redirecionado para a p&aacute;gina de impress&atilde;o do boleto em 5 segundos. <br />
+					Se isso n&atilde;o ocorrer, clique no bot&atilde;o "Exibir Boleto".
 				</p>
 				<script type="text/javascript"> 
 					window.setTimeout('abreJanelaBoleto(false)', 5000);
 				</script>
 			<?php } ?>
-	
-			<?php if (Mage::registry('current_order')) { ?>
+	         */?>
+			<?php if ($this->getOrder()) { ?>
 				<button type="button" class="form-button" target="boleto" onclick="abreJanelaBoleto(true)"><span>Exibir Boleto</span></button>
 			<?php } ?>
 	<?php } ?>

--- a/lib/boleto_php/boleto_bradesco.php
+++ b/lib/boleto_php/boleto_bradesco.php
@@ -74,12 +74,12 @@ $dadosboleto["demonstrativo1"] = $_POST["demonstrativo1"]; // "Pagamento de Comp
 $dadosboleto["demonstrativo2"] = $_POST["demonstrativo2"]; //"Mensalidade referente a nonon nonooon nononon<br>Taxa bancária - R$ ".number_format($taxa_boleto, 2, ',', '');
 $dadosboleto["demonstrativo3"] = $_POST["demonstrativo3"];
 if ($dadosboleto["demonstrativo2"] == '') {
-	$dadosboleto["demonstrativo2"] = "Taxa bancária - R$ " . number_format($taxa_boleto, 2, ',', '');
+	$dadosboleto["demonstrativo2"] = "Taxa bancária - R$ " . number_format((double)$taxa_boleto, 2, ',', '');
 }
 if ($dadosboleto["demonstrativo3"] == '') {
 	$dadosboleto["demonstrativo3"] = "&nbsp; Emitido pelo sistema Projeto BoletoPhp - www.boletophp.com.br";
 }
-$dadosboleto["demonstrativo2"] = str_replace('$taxa_boleto', number_format($taxa_boleto, 2, ',', ''), $dadosboleto["demonstrativo2"]);
+$dadosboleto["demonstrativo2"] = str_replace('$taxa_boleto', number_format((double)$taxa_boleto, 2, ',', ''), $dadosboleto["demonstrativo2"]);
 
 // INSTRUÇÕES PARA O CAIXA
 $dadosboleto["instrucoes1"] = $_POST["instrucoes1"]; // "- Sr. Caixa, cobrar multa de 2% após o vencimento";


### PR DESCRIPTION
Melhoria no processo getOrder() que nao exibia nem redirecionava corretamente o bloco em alguns templates e ocasioes;
Melhoria na forma como apresentava o html. Agora usa html entities ao inves de iso-8859 que quebrava em paginas de sucesso utf-8;
Correcao de notices na geracao de boleto do bradesco (parameter 1 should be double, string given).
Na minha pagina de sucesso o bloco de "voce sera redirecionado..." aparecia duas vezes. Tbm resolvido.